### PR TITLE
Playing with Rider and need special handling in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bld/
 # Visual Studio 2015 cache/options directory
 .vs/
 
+# Rider 2017.2 configuration files
+.idea/
+
 # NuGet Packages
 *.nupkg
 # The packages folder can be ignored because of Package Restore


### PR DESCRIPTION
Rider's config files don't belong in the repo.  This prevents that, based on what I've seen so far.